### PR TITLE
feat: update generate-publish to leave behind api-docs.json

### DIFF
--- a/generate-publish.sh
+++ b/generate-publish.sh
@@ -3,8 +3,9 @@ if [ ! -f "$PWD/swagger.json" ]; then
     echo "specs not found"
     exit 0
 fi
-swagger-inline "$PWD/src/**/*.(py|ts|js)" "$PWD/*.(py|ts|js)" -b "$PWD/swagger.json" -f ".json" | \
-strip-bom | \
+swagger-inline "$PWD/src/**/*.(py|ts|js)" "$PWD/*.(py|ts|js)" -b "$PWD/swagger.json" -f ".json" > api-docs.json
+
+strip-bom api-docs.json \
 jqf 'file => ({ "definition": JSON.stringify(file), "specification": "openapi/v3/json" })' | \
 curl \
   -X POST https://bump.sh/api/v1/docs/${BUMP_DOC_ID}/versions \


### PR DESCRIPTION
**Motivation**
We need a static file static API doc that could be used in other pipeline stages for hosting or security scanning.

**Intended use**
- We will update the [`publish-docs`](https://github.com/taxfix/devops-tools/blob/master/templates/.gitlab-ci-template.yml#L117) job to upload this file as an artefact of the job.
- Thereafter, all the subsequent jobs will be able to use this api-docs.json for any reason they want.